### PR TITLE
Chore/style adjustments

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -41,7 +41,7 @@
 
         {% for post in site.posts %}
           {% if post.tags contains "featured" %}
-          <div class="flex-box-50">
+          <div class="flex-box-33">
             <div class="flex-box-padding">
               <a data-w-id="06f08df4-8d04-178d-5325-4f7e27001551" href="{{ post.url }}" class="article-link-block w-inline-block">
                 <div class="post-container">

--- a/_posts/2020-03-16-keep-your-frontend-deps-up-to-date.md
+++ b/_posts/2020-03-16-keep-your-frontend-deps-up-to-date.md
@@ -75,7 +75,8 @@ if [ "HAS_NEW_DEPS" == "1" ]; then
   printf "$DEPENDENCY_CHECK_RESULT" > pr_description.txt
 
   echo "### Update PR description"
-  pip install --user PyGithub python ../.circleci/pull_request.py -t "Update Frontend deps" -b "frontend-update-${CIRCLE_SHA1}" -d pr_description.txt
+  pip install --user PyGithub
+  python ../.circleci/pull_request.py -t "Update Frontend deps" -b "frontend-update-${CIRCLE_SHA1}" -d pr_description.txt
 else
   echo "No dependency updates available"
 fi

--- a/assets/css/alasco-techblog.css
+++ b/assets/css/alasco-techblog.css
@@ -609,7 +609,8 @@ li {
 }
 
 .article pre{
-  white-space:pre-wrap;
+  white-space: pre;
+  overflow-x: auto;
 }
 
 .button_load_less {
@@ -740,11 +741,14 @@ li {
     -webkit-flex-basis: 70%;
     -ms-flex-preferred-size: 70%;
     flex-basis: 70%;
+    overflow: hidden;
+    overflow: hidden;
   }
   .flex-box-30 {
     -webkit-flex-basis: 30%;
     -ms-flex-preferred-size: 30%;
     flex-basis: 30%;
+    overflow: hidden;
   }
   .social-icon {
     width: 15px;
@@ -796,6 +800,7 @@ li {
     -webkit-flex-basis: 100%;
     -ms-flex-preferred-size: 100%;
     flex-basis: 100%;
+    overflow: hidden;
   }
   .job-box {
     margin-top: 30px;

--- a/assets/css/alasco-techblog.css
+++ b/assets/css/alasco-techblog.css
@@ -742,7 +742,6 @@ li {
     -ms-flex-preferred-size: 70%;
     flex-basis: 70%;
     overflow: hidden;
-    overflow: hidden;
   }
   .flex-box-30 {
     -webkit-flex-basis: 30%;

--- a/assets/css/alasco-techblog.css
+++ b/assets/css/alasco-techblog.css
@@ -283,6 +283,7 @@ li {
   transition: all 200ms ease;
   color: #046;
   text-decoration: none;
+  width: 100%;
 }
 
 .article-link-block:hover {


### PR DESCRIPTION
Small style adjustments!

- makes the article tiles a consistent width (no more wild west in the tile widths)
- prevents code blocks from wrapping, and instead has them become scrollable (so that the line numbers don't look messed up)

<details>
<summary>screenshots of article tiles</summary>

### Before: 
![tech blog - before change](https://user-images.githubusercontent.com/1109291/110840804-72abab80-82a5-11eb-9aad-f1b4b09aeebd.png)

### After: 
![tech blog - after change](https://user-images.githubusercontent.com/1109291/110840816-76d7c900-82a5-11eb-9999-93a568124b97.png)


</details>