### PR TITLE
Make code formatting (block & inline) look less broken

### DIFF
--- a/_posts/2022-01-07-custom-user-model.md
+++ b/_posts/2022-01-07-custom-user-model.md
@@ -31,8 +31,6 @@ So these are the steps we followed:
 
 We first defined a custom User model identical in structure to that of `django.contrib.auth`:
 
-<br/>
-
 ```python
 from django.contrib.auth.models import AbstractUser
 from django.contrib.auth.models import UserManager as BaseUserManager
@@ -49,8 +47,6 @@ class User(AbstractUser):
     class Meta:
         db_table = "auth_user"
 ```
-
-<br/>
 
 The manager definition turned out to be important for us, as without it we started getting errors saying that `User.objects` couldn't be used because the manager had been swapped out.
 
@@ -80,8 +76,6 @@ As a final touch of cleanup, we decided to start referring directly to our new U
 
 The second part of our adventure was to merge the User and Profile models together, as we could then have all the extended fields directly in the User model. For the main part we only had to do a migration to transfer the data from one model to the other, after creating the fields in the new User model. In order to make sure that all fields had been copied over, we included an assertion like this at the end of our data migration:
 
-<br/>
-
 ```python
 from django.db.models import  F
 
@@ -92,8 +86,6 @@ assert not User.objects.exclude(
     fieldn=F("profile__fieldn"),
 ).exists()
 ```
-
-<br/>
 
 The assertion made sure that the migration was reverted if any field was different. This was only possible in the context of an [atomic migration](https://docs.djangoproject.com/en/4.0/howto/writing-migrations/#non-atomic-migrations).
 

--- a/_posts/2022-03-23-cool-uris-dont-change-but-what-if-yours-arent.md
+++ b/_posts/2022-03-23-cool-uris-dont-change-but-what-if-yours-arent.md
@@ -15,11 +15,11 @@ URLs are for web applications what doors are for buildings. As long as they take
 
 ## Our domain is moving
 
-Over the last three years, the Alasco application has grown from a small cost controlling tool into a widely used SaaS construction finance management suite. Along with this growth, the domain that we are covering has evolved at high pace: With each passing quarter the product is growing into new areas, shifting away from less successful ones and undergoing significant refinement — our very understanding of _what it is that we are building_ is moving.
+Over the last three years, the Alasco application has grown from a small cost controlling tool into a widely used SaaS construction finance management suite. Along with this growth, the domain that we are covering has evolved at high pace: With each passing quarter the product is growing into new areas, shifting away from less successful ones and undergoing significant refinement — our very understanding of _what it is that we are building_ changes.
 
 The app was once structured in categories such as `Estimating`, `Contracting` and `Invoice processsing` — by now our product areas are instead `Costs`, `Incomes`, `KPIs`, etc. We continue to adjust both the user-facing product and our internal codebase to keep up with the improving model of our domain.
 
-We moved slower, however, in refactoring URLs of existing pages, because, well, [cool URIs don’t change](https://www.w3.org/Provider/Style/URI). We decided to do it anyways, because with years of accumulated changes in the product, our URLs were far from being “cool” anymore. We saw significant user value in doing so: most users still see URLs on the top of their browser window and we wanted to support them by keeping URLs readable, concise, and a helpful guide of where in the application they are and of what they are doing.
+We moved slower, however, in refactoring URLs of existing pages, because, well, [cool URIs don’t change](https://www.w3.org/Provider/Style/URI). We recently decided to do it anyways, because with years of accumulated changes in the product, our URLs were far from being “cool” anymore. We saw significant user value in doing so: most users still see URLs on the top of their browser window and we wanted to support them by keeping URLs readable, concise, and a helpful guide of where in the application they are and of what they are doing.
 
 ## Helpful URLs: predictable, consistent, and clean
 

--- a/assets/css/alasco-techblog.css
+++ b/assets/css/alasco-techblog.css
@@ -599,24 +599,26 @@ li {
 
 .paragraph-article.code-snippet {
   font-family: Inconsolata, monospace;
-  font-size: 90%;
+  font-size: 1em;
 }
 
 .article code {
   font-family: Inconsolata, monospace;
-  font-size: 90%;
-  padding: 2px 4px;
-  background-color: #f9f2f4;
-  border-radius: 4px;
+  font-size: 1em;
 }
 
+.article p > code {
+  padding: 2px 4px;
+  background-color: #f8f8f8;
+  border-radius: 4px;
+}
 .article pre {
   white-space: pre;
   overflow-x: auto;
   margin: 1em 0em;
   max-width: 100%;
   color: #1b1b32;
-  font-size: 1.2rem;
+  font-size: 1.1em;
   background-color: #f8f8f8;
   border: 1px solid #ccc;
   padding: 10px;

--- a/assets/css/alasco-techblog.css
+++ b/assets/css/alasco-techblog.css
@@ -4,7 +4,7 @@
   padding-bottom: 0px;
   padding-left: 0px;
   padding-right: 0px;
-  background-image: url('https://d3e54v103j8qbb.cloudfront.net/static/youtube-placeholder.2b05e7d68d.svg');
+  background-image: url("https://d3e54v103j8qbb.cloudfront.net/static/youtube-placeholder.2b05e7d68d.svg");
   background-size: cover;
   background-position: 50% 50%;
 }
@@ -445,7 +445,7 @@ li {
 }
 
 .accordion_toggle_form.w--open {
-  background-image: url('../images/close_icon_bue_1close_icon_bue.png');
+  background-image: url("../images/close_icon_bue_1close_icon_bue.png");
   background-position: 99% 50%;
   color: #2897f3;
 }
@@ -533,7 +533,6 @@ li {
   color: #066;
 }
 
-
 .link-to-top {
   margin-top: 25px;
   padding: 15px 25px;
@@ -590,7 +589,7 @@ li {
   line-height: 1.5em;
 }
 
-.article p{
+.article p {
   font-size: 1.1em;
 }
 
@@ -600,17 +599,28 @@ li {
 
 .paragraph-article.code-snippet {
   font-family: Inconsolata, monospace;
-  font-size: 0.9em;
+  font-size: 90%;
 }
 
 .article code {
   font-family: Inconsolata, monospace;
-  font-size: 0.9em;
+  font-size: 90%;
+  padding: 2px 4px;
+  background-color: #f9f2f4;
+  border-radius: 4px;
 }
 
-.article pre{
+.article pre {
   white-space: pre;
   overflow-x: auto;
+  margin: 1em 0em;
+  max-width: 100%;
+  color: #1b1b32;
+  font-size: 1.2rem;
+  background-color: #f8f8f8;
+  border: 1px solid #ccc;
+  padding: 10px;
+  border-radius: 3px;
 }
 
 .button_load_less {
@@ -853,4 +863,3 @@ li {
     flex-basis: 100%;
   }
 }
-

--- a/assets/css/alasco-techblog.css
+++ b/assets/css/alasco-techblog.css
@@ -611,6 +611,7 @@ li {
   padding: 2px 4px;
   background-color: #f8f8f8;
   border-radius: 4px;
+  border: 1px solid #ccc;
 }
 .article pre {
   white-space: pre;


### PR DESCRIPTION
Adds background highlighting for code blocks and slight background style for inline code snippets.

Before:
<img width="704" alt="Screenshot 2022-03-24 at 08 41 22" src="https://user-images.githubusercontent.com/2837099/159866573-67e8163a-2ec0-4210-898d-02cd792be9e9.png">


After:
<img width="704" alt="Screenshot 2022-03-24 at 08 41 01" src="https://user-images.githubusercontent.com/2837099/159866605-f9131896-3de6-4da1-8da3-58ba1ce6a137.png">


Alternative?
<img width="704" alt="Screenshot 2022-03-24 at 08 40 37" src="https://user-images.githubusercontent.com/2837099/159866669-36a0e188-5e02-4b62-a49e-e29d49ecb544.png">

